### PR TITLE
Renderers

### DIFF
--- a/lib/i18n_flow/cli.rb
+++ b/lib/i18n_flow/cli.rb
@@ -33,6 +33,6 @@ class I18nFlow::CLI
     end
 
     command_class = COMMANDS[command] || COMMANDS['help']
-    command_class.new(args).invoke
+    command_class.new(args).invoke!
   end
 end

--- a/lib/i18n_flow/cli/command_base.rb
+++ b/lib/i18n_flow/cli/command_base.rb
@@ -16,14 +16,6 @@ class I18nFlow::CLI
       raise 'Not implemented'
     end
 
-    def invoke
-      begin
-        invoke!
-      rescue => e
-        exit_with_message(1, '[%s] %s' % [e.class.name, e.message])
-      end
-    end
-
     def exit_with_message(status, *args)
       if status.zero?
         puts(*args)

--- a/lib/i18n_flow/cli/command_base.rb
+++ b/lib/i18n_flow/cli/command_base.rb
@@ -2,17 +2,6 @@ require_relative '../util'
 
 class I18nFlow::CLI
   class CommandBase
-    COLORS = {
-      black:   30,
-      red:     31,
-      green:   32,
-      yellow:  33,
-      blue:    34,
-      magenta: 35,
-      cyan:    36,
-      white:   37,
-    }
-
     attr_reader(*%i[
       args
       options
@@ -43,10 +32,6 @@ class I18nFlow::CLI
       end
 
       exit status
-    end
-
-    def color(str, c)
-      "\e[1;#{COLORS[c]}m#{str}\e[0m"
     end
   end
 end

--- a/lib/i18n_flow/cli/lint_command.rb
+++ b/lib/i18n_flow/cli/lint_command.rb
@@ -1,108 +1,30 @@
 require_relative 'command_base'
 require_relative '../repository'
-require_relative '../validator/errors'
 require_relative '../validator/multiplexer'
 
 class I18nFlow::CLI
   class LintCommand < CommandBase
+    require_relative 'lint_command/ascii_renderer'
+
     def invoke!
       validator.validate!
-      print_errors
-    end
 
-    def print_errors
-      file_count  = 0
-      error_count = 0
-
-      validator.errors.each do |file, errors|
-        file_count += 1
-        puts '=== %s' % [color(file, :yellow)]
-
-        errors.each do |full_key, err|
-          error_count += 1
-          puts print_key(full_key, err.line)
-          print color(format_error(err), :red)
-        end
-
-        puts
+      case output_format
+      when 'ascii', nil
+        puts AsciiRenderer.new(validator.errors).render
+      else
+        exit_with_message(1, 'Unsupported format: %s' % [output_format])
       end
 
-      summary = 'Found %d %s in %d %s' % [
-        error_count,
-        error_count == 1 ? 'violation' : 'violations',
-        file_count,
-        file_count == 1 ? 'file' : 'files',
-      ]
+      exit validator.errors.size.zero? ? 0 : 1
+    end
 
-      exit_with_message(error_count.zero? ? 0 : 1, summary)
+    def output_format
+      return @output_format if defined?(@output_format)
+      @output_format = options['format'] || options['f']
     end
 
   private
-
-    def print_key(full_key, line)
-      line = '#%d' % [line]
-      '    %s  %s' % [full_key, color(line, :yellow)]
-    end
-
-    def format_error(err)
-      case err
-      when I18nFlow::Validator::InvalidTypeError
-        if err.single?
-          <<-MESSAGE
-        the top-level scope must match with the file path
-        reason: unexpected structure
-          MESSAGE
-        else
-          <<-MESSAGE
-        the structure mismatches with the master file
-          MESSAGE
-        end
-      when I18nFlow::Validator::MissingKeyError
-        if err.single?
-          <<-MESSAGE
-        the top-level scope must match with the file path
-        reason: missing key
-          MESSAGE
-        else
-          <<-MESSAGE
-        missing key
-          MESSAGE
-        end
-      when I18nFlow::Validator::ExtraKeyError
-        if err.single?
-          <<-MESSAGE
-        the top-level scope must match with the file path
-        reason: extra key
-          MESSAGE
-        else
-          <<-MESSAGE
-        extra key
-          MESSAGE
-        end
-      when I18nFlow::Validator::InvalidTodoError
-        <<-MESSAGE
-        todo cannot be tagged on mapping/sequence
-        MESSAGE
-      when I18nFlow::Validator::TodoContentError
-        <<-MESSAGE
-        has "todo" but the content diverges from the master file
-        master: #{err.expect}
-        got:    #{err.actual}
-        MESSAGE
-      when I18nFlow::Validator::InvalidLocaleError
-        <<-MESSAGE
-        has "only" but the locale is invalid
-        valid: [#{err.expect.join(', ')}]
-        got:   #{err.actual}
-        MESSAGE
-      when I18nFlow::Validator::AsymmetricArgsError
-        <<-MESSAGE
-        interpolation arguments diverge from the master file
-        master: [#{err.expect.join(', ')}]
-        got:    [#{err.actual.join(', ')}]
-        MESSAGE
-      end
-    end
 
     def repository
       @repository ||= I18nFlow::Repository.new(

--- a/lib/i18n_flow/cli/lint_command.rb
+++ b/lib/i18n_flow/cli/lint_command.rb
@@ -5,13 +5,18 @@ require_relative '../validator/multiplexer'
 class I18nFlow::CLI
   class LintCommand < CommandBase
     require_relative 'lint_command/ascii_renderer'
+    require_relative 'lint_command/markdown_renderer'
+
+    DEFAULT_FORMAT = 'ascii'
 
     def invoke!
       validator.validate!
 
       case output_format
-      when 'ascii', nil
+      when 'ascii'
         puts AsciiRenderer.new(validator.errors).render
+      when 'markdown'
+        puts MarkdownRenderer.new(validator.errors, url_formatter: url_formatter).render
       else
         exit_with_message(1, 'Unsupported format: %s' % [output_format])
       end
@@ -20,8 +25,12 @@ class I18nFlow::CLI
     end
 
     def output_format
-      return @output_format if defined?(@output_format)
-      @output_format = options['format'] || options['f']
+      @output_format ||= options['format'] || DEFAULT_FORMAT
+    end
+
+    def url_formatter
+      @url_formatter = options['url-formatter']
+      @url_formatter ||= "file://#{I18nFlow.config.base_path}/%f#%l"
     end
 
   private

--- a/lib/i18n_flow/cli/lint_command/ascii.erb
+++ b/lib/i18n_flow/cli/lint_command/ascii.erb
@@ -1,0 +1,45 @@
+<%- errors.each do |file, errs| -%>
+=== <%= file %>
+  <%- errs.each do |full_key, err| -%>
+    <%= full_key %>  #<%= err.line %>
+    <%- case err when nil -%>
+    <%- when I18nFlow::Validator::InvalidTypeError -%>
+      <%- if err.single? -%>
+        A file must start with scopes that derive from its file path
+        reason: it must not have a scalar value
+      <%- else -%>
+        Structure mismatches with the master file
+      <%- end -%>
+    <%- when I18nFlow::Validator::MissingKeyError -%>
+      <%- if err.single? -%>
+        A file must start with scopes that derive from its file path
+        reason: missing key
+      <%- else -%>
+        The key is missing
+      <%- end -%>
+    <%- when I18nFlow::Validator::ExtraKeyError -%>
+      <%- if err.single? -%>
+        A file must start with scopes that derive from its file path
+        reason: extra key
+      <%- else -%>
+        The key is extra
+      <%- end -%>
+    <%- when I18nFlow::Validator::InvalidTodoError -%>
+        Todo cannot be annotated on a mapping/sequence
+    <%- when I18nFlow::Validator::TodoContentError -%>
+        It has "!todo" but the content diverges from the master file
+        master:  <%= err.expect %>
+        foreign: <%= err.actual %>
+    <%- when I18nFlow::Validator::InvalidLocaleError -%>
+        It has "only" but the locale is invalid
+        valid: [<%= err.expect.join(', ') %>]
+        got:   <%= err.actual %>
+    <%- when I18nFlow::Validator::AsymmetricArgsError -%>
+        Interpolation arguments diverge from the master file
+        master:  [<%= err.expect.join(', ') %>]
+        foreign: [<%= err.actual.join(', ') %>]
+    <%- end -%>
+  <%- end -%>
+
+<%- end -%>
+<%= summary_line %>

--- a/lib/i18n_flow/cli/lint_command/ascii_renderer.rb
+++ b/lib/i18n_flow/cli/lint_command/ascii_renderer.rb
@@ -1,0 +1,70 @@
+require 'erb'
+require_relative '../../validator/errors'
+
+class I18nFlow::CLI::LintCommand
+  class AsciiRenderer
+    COLORS = {
+      black:   30,
+      red:     31,
+      green:   32,
+      yellow:  33,
+      blue:    34,
+      magenta: 35,
+      cyan:    36,
+      white:   37,
+    }.freeze
+
+    FILE = __dir__ + '/ascii.erb'
+
+    attr_reader :errors
+
+    def initialize(errors, color: true)
+      @errors = errors
+      @color_enabled = !!color
+    end
+
+    def render
+      with_color(erb.result(binding))
+    end
+
+    def color_enabled?
+      @color_enabled
+    end
+
+    def file_count
+      @file_count ||= errors.size
+    end
+
+    def error_count
+      @error_count ||= errors.sum { |_, errs| errs.size }
+    end
+
+    def summary_line
+      @summary_line ||= 'Found %d %s in %d %s' % [
+        error_count,
+        error_count == 1 ? 'violation' : 'violations',
+        file_count,
+        file_count == 1 ? 'file' : 'files',
+      ]
+    end
+
+  private
+
+    def with_color(str)
+      return str unless color_enabled?
+
+      str = str.gsub(/^(=== )(.+)$/) { $1 + color($2, :yellow) }
+      str = str.gsub(/(#\d+)$/) { color($1, :yellow) }
+      str = str.gsub(/^([ ]{8})(.+)$/) { $1 + color($2, :red) }
+      str
+    end
+
+    def color(str, c)
+      "\e[1;#{COLORS[c]}m#{str}\e[0m"
+    end
+
+    def erb
+      @erb ||= ERB.new(File.read(FILE), 0, '-')
+    end
+  end
+end

--- a/lib/i18n_flow/cli/lint_command/markdown.erb
+++ b/lib/i18n_flow/cli/lint_command/markdown.erb
@@ -1,0 +1,50 @@
+[I18nFlow] <%= summary_line %>
+
+---
+
+<%- errors.each do |file, errs| -%>
+## [<%= file %>]()
+
+  <%- errs.each do |full_key, err| -%>
+### <%= full_key %>
+
+    <%- case err when nil -%>
+    <%- when I18nFlow::Validator::InvalidTypeError -%>
+      <%- if err.single? -%>
+A file must start with scopes that derive from its file path [<%= err.file %>:<%= err.line %>]()
+reason: it must not have a scalar value
+      <%- else -%>
+Structure mismatches with the master file [<%= err.file %>:<%= err.line %>]()
+      <%- end -%>
+    <%- when I18nFlow::Validator::MissingKeyError -%>
+      <%- if err.single? -%>
+A file must start with scopes that derive from its file path [<%= err.file %>:<%= err.line %>]()
+reason: missing key
+      <%- else -%>
+The key is missing [<%= err.file %>:<%= err.line %>]()
+      <%- end -%>
+    <%- when I18nFlow::Validator::ExtraKeyError -%>
+      <%- if err.single? -%>
+A file must start with scopes that derive from its file path [<%= err.file %>:<%= err.line %>]()
+reason: extra key
+      <%- else -%>
+The key is extra [<%= err.file %>:<%= err.line %>]()
+      <%- end -%>
+    <%- when I18nFlow::Validator::InvalidTodoError -%>
+Todo cannot be annotated on a mapping/sequence [<%= err.file %>:<%= err.line %>]()
+    <%- when I18nFlow::Validator::TodoContentError -%>
+It has "!todo" but the content diverges from the master file [<%= err.file %>:<%= err.line %>]()
+master: `<%= err.expect %>`
+foreign: `<%= err.actual %>`
+    <%- when I18nFlow::Validator::InvalidLocaleError -%>
+It has "only" but the locale is invalid [<%= err.file %>:<%= err.line %>]()
+valid: `[<%= err.expect.join(', ') %>]`
+got: `<%= err.actual %>`
+    <%- when I18nFlow::Validator::AsymmetricArgsError -%>
+Interpolation arguments diverge from the master file [<%= err.file %>:<%= err.line %>]()
+master: `[<%= err.expect.join(', ') %>]`
+foreign: `[<%= err.actual.join(', ') %>]`
+    <%- end -%>
+  <%- end -%>
+
+<%- end -%>

--- a/lib/i18n_flow/cli/lint_command/markdown_renderer.rb
+++ b/lib/i18n_flow/cli/lint_command/markdown_renderer.rb
@@ -1,0 +1,56 @@
+require 'erb'
+require_relative '../../validator/errors'
+
+class I18nFlow::CLI::LintCommand
+  class MarkdownRenderer
+    FILE = __dir__ + '/markdown.erb'
+
+    attr_reader :errors
+    attr_reader :url_formatter
+
+    def initialize(errors, url_formatter:)
+      @errors = errors
+      @url_formatter = url_formatter
+    end
+
+    def render
+      with_link(erb.result(binding))
+    end
+
+    def file_count
+      @file_count ||= errors.size
+    end
+
+    def error_count
+      @error_count ||= errors.sum { |_, errs| errs.size }
+    end
+
+    def summary_line
+      @summary_line ||= 'Found %d %s in %d %s' % [
+        error_count,
+        error_count == 1 ? 'violation' : 'violations',
+        file_count,
+        file_count == 1 ? 'file' : 'files',
+      ]
+    end
+
+  private
+
+    def with_link(str)
+      str.gsub(/\[(([^\]:]+)(?::(\d+))?)\]\(\)/) do
+        '[%s](%s)' % [$1, link($2, $3)]
+      end
+    end
+
+    def link(path, line)
+      url = url_formatter
+      url = url.gsub(/%f\b/, path)
+      url = url.gsub(/%l\b/, line.to_s)
+      url
+    end
+
+    def erb
+      @erb ||= ERB.new(File.read(FILE), 0, '-')
+    end
+  end
+end

--- a/spec/lib/i18n_flow/cli/command_base_spec.rb
+++ b/spec/lib/i18n_flow/cli/command_base_spec.rb
@@ -11,18 +11,6 @@ describe I18nFlow::CLI::CommandBase do
     end
   end
 
-  describe '#invoke' do
-    it 'should call `invoke!`' do
-      expect(command).to receive(:invoke!).and_return(nil)
-      command.invoke
-    end
-
-    it 'should exit with an error message' do
-      expect(command).to receive(:exit_with_message)
-      command.invoke
-    end
-  end
-
   describe '#exit_with_message' do
     let(:message)        { 'a message' }
     let(:message_regexp) { /a message/ }


### PR DESCRIPTION
## Why

To support different output format

## What

- Extract a renderer logic from LintCommand
- Create new markdown renderer