### PR TITLE
Quote non-string keys

### DIFF
--- a/lib/i18n_flow/yaml_ast_proxy.rb
+++ b/lib/i18n_flow/yaml_ast_proxy.rb
@@ -90,4 +90,8 @@ private
       .tap { |n| break unless n.is_a?(Psych::Nodes::Mapping) }
       &.tap { |n| break n.children[layout_offset] }
   end
+
+  def self.scalar_scanner
+    @scalar_scanner ||= Psych::ScalarScanner.new(Psych::ClassLoader.new)
+  end
 end

--- a/lib/i18n_flow/yaml_ast_proxy/mapping.rb
+++ b/lib/i18n_flow/yaml_ast_proxy/mapping.rb
@@ -79,7 +79,7 @@ module I18nFlow::YamlAstProxy
     def synchronize!
       return if @locked
 
-      children = indexed_object.flat_map { |k, v| [Psych::Nodes::Scalar.new(k), v] }
+      children = indexed_object.flat_map { |k, v| [key_node(k), v] }
       node.children.replace(children)
     end
 
@@ -93,6 +93,15 @@ module I18nFlow::YamlAstProxy
       when Psych::Nodes::Alias then -1
       when Psych::Nodes::Mapping then node.anchor ? 0 : 1
       else node.anchor ? -2 : 0
+      end
+    end
+
+    def key_node(str)
+      needs_quote = !I18nFlow::YamlAstProxy.scalar_scanner.tokenize(str).is_a?(String)
+      if needs_quote
+        Psych::Nodes::Scalar.new(str, nil, nil, true, true, Psych::Nodes::Scalar::DOUBLE_QUOTED)
+      else
+        Psych::Nodes::Scalar.new(str, nil, nil, true, false, Psych::Nodes::Scalar::PLAIN)
       end
     end
   end

--- a/spec/lib/i18n_flow/formatter_spec.rb
+++ b/spec/lib/i18n_flow/formatter_spec.rb
@@ -8,6 +8,28 @@ describe I18nFlow::Formatter do
   end
 
   describe '#format!' do
+    it 'should quote non-string keys' do
+      ast = parse_yaml(<<-YAML)
+      en:
+        1: alpha
+        1.2: bravo
+        foo: chalie
+        true: delta
+      YAML
+      result = parse_yaml(<<-YAML)
+      en:
+        "1": alpha
+        "1.2": bravo
+        foo: chalie
+        "true": delta
+      YAML
+
+      p ast
+
+      formatted = format_ast(ast)
+      expect(formatted.to_yaml).to eq(result.to_yaml)
+    end
+
     it 'should remove extra whitespaces' do
       ast = parse_yaml(<<-YAML)
       en:


### PR DESCRIPTION
## Why

https://github.com/ruby/psych/blob/master/lib/psych/scalar_scanner.rb

Some literal are parsed into non-string values and `I18n.t` can't resolve translation for such case.

```yaml
en:
  foo:
    true: 'Hello'
```

```ruby
I18n.t("foo.true", locale: :en)
# I18n::MissingTranslationData: translation missing: en.foo.true
```