### PR TITLE
Conform to YAML spec where flow indicators can't be in shorthand tags

### DIFF
--- a/doc/tags.md
+++ b/doc/tags.md
@@ -172,7 +172,7 @@ Linter won't complain about `ja.desc`
 -------------
 
 It's similar to `!only`, but is stricter.  
-It can take comma-separated locales as a parameter just like `!only:en` or `!only:en,ja,zh-HK`, and ensures that a key only exists in files of the specified locales.
+It can take comma-separated locales as a parameter just like `!only:en` or `!<!only:en,ja,zh-HK>`, and ensures that a key only exists in files of the specified locales.
 
 <table><thead><tr>
   <th></th>
@@ -235,7 +235,7 @@ Linter will complain about `en.desc`, because the key is supposed to exist only 
 ```yaml
 en:
   title: 'Non zero sum'
-  desc: !only:en,ja 'A situation in...'
+  desc: !<!only:en,ja> 'A situation in...'
 ```
 
 </td><td>
@@ -261,7 +261,7 @@ The key can exist in the specified locales `en,ja`
 ```yaml
 en:
   title: 'Non zero sum'
-  desc: !only:en,ja 'A situation in...'
+  desc: !<!only:en,ja> 'A situation in...'
 ```
 
 </td><td>

--- a/spec/lib/i18n_flow/validator/symmetry_spec.rb
+++ b/spec/lib/i18n_flow/validator/symmetry_spec.rb
@@ -252,12 +252,12 @@ describe I18nFlow::Validator::Symmetry do
         ast_1 = parse_yaml(<<-YAML)['en']
         en:
           key_1: text_1
-          key_2: !only:en,ja text_2
+          key_2: !<!only:en,ja> text_2
         YAML
         ast_2 = parse_yaml(<<-YAML)['ja']
         ja:
           key_1: text_1
-          key_2: !only:en,ja text_2
+          key_2: !<!only:en,ja> text_2
         YAML
 
         allow(validator).to receive(:ast_1).and_return(ast_1)


### PR DESCRIPTION
libyaml [now rejects](https://github.com/yaml/libyaml/pull/179) tags like `!only:en,ja` and we need to write `!<!only:en,ja>` instead.